### PR TITLE
Ruby 2.3 frozen string compat

### DIFF
--- a/okjson.rb
+++ b/okjson.rb
@@ -341,7 +341,7 @@ private
             end
           end
           if rubydoesenc?
-            a[w] = '' << uchar
+            a[w] = uchar.chr(''.encoding)
             w += 1
           else
             w += ucharenc(a, w, uchar)


### PR DESCRIPTION
Permit running on Ruby 2.3 with --enable-frozen-string-literal